### PR TITLE
Fix closing socket in brazil's HttpRequest

### DIFF
--- a/src/sunlabs/brazil/util/http/HttpRequest.java
+++ b/src/sunlabs/brazil/util/http/HttpRequest.java
@@ -840,6 +840,11 @@ public class HttpRequest
 	    pool.close(hs, keepAlive);
 	    killer.interrupt();
 	}
+
+	public void abort() {
+		pool.close(hs, false);
+		this.interrupt();
+	}
     }
 
     static class Killer extends Thread
@@ -855,7 +860,7 @@ public class HttpRequest
 	{
 	    try {
 		Thread.sleep(b.timeout);
-		b.interrupt();
+		b.abort();
 	    } catch (Exception e) {}
 	}
     }


### PR DESCRIPTION
When calling close() on an HttpRequest instance brazil checks whether
keep-alive is supported. If so, it puts the open connection into a
pool for later re-use.

If there is still data to be received from the socket, a
BackgroundCloser thread is created that a) attempts to read
the remaining data from the socket and b) spawns a Killer
that signals an interrupt to the BackgroundCloser after ten
seconds.

This interrupt, however, does not cause the InputStream.read()
to throw an exception which would in turn get the socket from
the pool closed but rather only kills the thread with the socket
still being open.

This leads to the problem described here in
https://adblockplus.org/forum/viewtopic.php?f=15&t=11790:
When an HTTP stream gets opened and the client application
terminates, the socket is still being held open and data gets
received until the connection is closed for some other reason.

This patch makes Killer call an abort() method of BackgroundCloser
which in turn closes the socket and kills the BackgroundCloser thread.
